### PR TITLE
Added the ability to save prompts based on URL pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Web Content AI Summary Youtube Trancripts and Webpages.
+# Web Content AI Summary - YouTube Transcripts and Webpages
 
 A Chrome extension that helps analyze and discuss content from any webpage or YouTube video using AI.
 
@@ -14,7 +14,11 @@ https://github.com/user-attachments/assets/3fd1d773-f416-4ffd-8308-5cad147676f8
 - 💬 Interactive chat interface for follow-up questions
 - 🎨 Dark mode interface with cyberpunk-inspired design
 - ⚙️ Configurable AI model settings
-- 📝 Customizable system prompts
+- 📝 URL-based prompt management:
+  - Save custom prompts for specific URLs or URL patterns
+  - Automatic prompt selection based on current webpage
+  - Edit and manage saved prompts
+  - Longer URL patterns take precedence (e.g., reddit.com/user/* over reddit.com/*)
 - 📋 Easy content copying
 
 ## Requirements
@@ -42,19 +46,35 @@ https://github.com/user-attachments/assets/3fd1d773-f416-4ffd-8308-5cad147676f8
 
 ## Usage
 
+### Managing Prompts
+1. Click the prompt manager icon (📝) in the extension
+2. To add a new prompt:
+   - Enter a URL pattern (e.g., reddit.com/user)
+   - Write your custom prompt
+   - Click Save
+3. To use current page URL:
+   - Click "Get URL" to automatically fill the pattern
+   - Modify as needed (remove specific parts for broader matching)
+4. Edit or delete existing prompts using the buttons on each prompt card
+5. Prompts are automatically selected based on the current webpage URL
+   - More specific patterns (longer URLs) take precedence
+   - You can always modify the selected prompt before summarizing
+
 ### For Any Webpage
 1. Navigate to any webpage
 2. Click the extension icon to open the side panel
 3. Click "Get Page Content" to extract the main content
-4. Click "Summarize Page with AI" to generate a summary
-5. Ask follow-up questions in the chat interface
+4. The appropriate prompt will be automatically selected based on the URL
+5. Click "Summarize Page with AI" to generate a summary
+6. Ask follow-up questions in the chat interface
 
 ### For YouTube Videos
 1. Navigate to any YouTube video
 2. Click the extension icon to open the side panel
 3. Click "Get Transcript" to fetch the video transcript
-4. Click "Summarize Page with AI" to generate a summary
-5. Ask follow-up questions in the chat interface
+4. The appropriate prompt will be automatically selected based on the URL
+5. Click "Summarize Page with AI" to generate a summary
+6. Ask follow-up questions in the chat interface
 
 ## Settings
 ![image](https://github.com/user-attachments/assets/040c5a11-237e-4a77-8829-bf294aecd109)

--- a/extension/app.js
+++ b/extension/app.js
@@ -342,7 +342,7 @@ const ui = {
         selector.innerHTML = '<option value="default">Default System Prompt</option>';
 
         // Add saved prompts as options
-        Object.entries(savedPrompts).forEach(([pattern, prompt]) => {
+        Object.entries(savedPrompts).forEach(([pattern, ]) => {
             const option = document.createElement('option');
             option.value = pattern;
             option.textContent = pattern;
@@ -357,8 +357,10 @@ const ui = {
 
         if (bestMatch) {
             selector.value = bestMatch;
+            systemPromptArea.value = savedPrompts[bestMatch];
         } else {
             selector.value = 'default';
+            systemPromptArea.value = defaultPrompt;
         }
     }
 };
@@ -525,7 +527,9 @@ const handlers = {
 
     async handleManagePrompts() {
         const container = document.querySelector('#panel-content');
-        if (!container) return;
+        if (!container) {
+            return;
+        }
 
         // Save current content to restore later if needed
         const previousContent = container.innerHTML;
@@ -664,22 +668,6 @@ const promptManager = {
         const cleanPattern = pattern.replace(/^www\./, '');
         savedPrompts[cleanPattern] = prompt;
         await chrome.storage.sync.set({ savedPrompts });
-    },
-
-    async getPromptForUrl(url) {
-        const { savedPrompts = {} } = await chrome.storage.sync.get('savedPrompts');
-
-        // Clean the URL for matching
-        const urlObj = new URL(url);
-        const cleanUrl = `${urlObj.hostname}${urlObj.pathname}`.replace(/^www\./, '');
-
-        // Find all matching patterns and sort by length (longest first)
-        const matches = Object.entries(savedPrompts)
-            .filter(([pattern]) => cleanUrl.includes(pattern))
-            .sort(([patternA], [patternB]) => patternB.length - patternA.length);
-
-        // Return the longest matching pattern's prompt, or default
-        return matches[0]?.[1] || await api.getSystemPrompt();
     },
 
     findBestMatchForUrl(url, patterns) {

--- a/extension/app.js
+++ b/extension/app.js
@@ -683,16 +683,7 @@ async function loadPrompts() {
     const { savedPrompts = {} } = await chrome.storage.sync.get('savedPrompts');
 
     promptsList.innerHTML = Object.entries(savedPrompts)
-        .map(([pattern, content]) => `
-            <div class="prompt-item">
-                <div class="prompt-pattern">${pattern}</div>
-                <div class="prompt-content">${content}</div>
-                <div class="prompt-actions">
-                    <button class="btn" data-action="edit" data-pattern="${pattern}">Edit</button>
-                    <button class="btn danger-btn" data-action="delete" data-pattern="${pattern}">Delete</button>
-                </div>
-            </div>
-        `)
+        .map(([pattern, content]) => renderTemplate('promptItem', { pattern, content }))
         .join('');
 }
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -360,7 +360,7 @@ const ui = {
             systemPromptArea.value = savedPrompts[bestMatch];
         } else {
             selector.value = 'default';
-            systemPromptArea.value = defaultPrompt;
+            systemPromptArea.value = await api.getSystemPrompt();
         }
     }
 };

--- a/extension/side-panel.html
+++ b/extension/side-panel.html
@@ -23,7 +23,7 @@
                     <option value="default">Default System Prompt</option>
                 </select>
             </div>
-            <textarea id="system-prompt" rows="3" cols="50" placeholder="System Prompt"></textarea>
+            <textarea id="system-prompt" rows="6" cols="50" placeholder="System Prompt"></textarea>
             <button id="summarize-transcript" class="btn ai-btn">Summarize Page with AI</button>
             <textarea id="transcript-area" rows="5" cols="50" placeholder="Content will appear here..."></textarea>
             <div class="button-group source-buttons">

--- a/extension/side-panel.html
+++ b/extension/side-panel.html
@@ -18,19 +18,17 @@
             </div>
         </header>
         <div class="panel-content" id="panel-content">
-            <button id="summarize-transcript" class="btn ai-btn">Summarize Page with AI</button>
-            <div class="button-group source-buttons">
-                <button id="fetch-webpage" class="btn">Get Page Content</button>
-                <button id="fetch-current-transcript" class="btn">Get Transcript</button>
-            </div>
             <div class="prompt-selector">
                 <select id="prompt-selector">
                     <option value="default">Default System Prompt</option>
                 </select>
             </div>
             <textarea id="system-prompt" rows="3" cols="50" placeholder="System Prompt"></textarea>
+            <button id="summarize-transcript" class="btn ai-btn">Summarize Page with AI</button>
             <textarea id="transcript-area" rows="5" cols="50" placeholder="Content will appear here..."></textarea>
-            <div class="button-group">
+            <div class="button-group source-buttons">
+                <button id="fetch-webpage" class="btn">Get Page Content</button>
+                <button id="fetch-current-transcript" class="btn">Get Transcript</button>
                 <button id="copy-to-clipboard" class="btn">Copy to Clipboard</button>
             </div>
         </div>

--- a/extension/side-panel.html
+++ b/extension/side-panel.html
@@ -13,6 +13,7 @@
         <header>
             <h1>Web Content Assistant</h1>
             <div class="header-buttons">
+                <button id="manage-prompts" class="settings-btn" title="Manage Prompts">📝</button>
                 <button id="open-options" class="settings-btn" title="Settings">⚙️</button>
             </div>
         </header>
@@ -21,6 +22,11 @@
             <div class="button-group source-buttons">
                 <button id="fetch-webpage" class="btn">Get Page Content</button>
                 <button id="fetch-current-transcript" class="btn">Get Transcript</button>
+            </div>
+            <div class="prompt-selector">
+                <select id="prompt-selector">
+                    <option value="default">Default System Prompt</option>
+                </select>
             </div>
             <textarea id="system-prompt" rows="3" cols="50" placeholder="System Prompt"></textarea>
             <textarea id="transcript-area" rows="5" cols="50" placeholder="Content will appear here..."></textarea>

--- a/extension/style.css
+++ b/extension/style.css
@@ -568,7 +568,7 @@ hr {
 }
 
 .prompt-item {
-    background: var(--message-bg-user);
+    background: var(--message-bg-ai);
     padding: var(--spacing-md);
     margin: var(--spacing-sm) 0;
     border-radius: var(--border-radius);
@@ -577,8 +577,9 @@ hr {
 }
 
 .prompt-pattern {
-    font-size: var(--font-size-sm);
-    color: var(--primary-color);
+    font-size: var(--font-size-md);
+    color: var(--text-color);
+    font-weight: var(--font-weight-semibold);
     margin-bottom: var(--spacing-xs);
 }
 
@@ -588,17 +589,15 @@ hr {
 }
 
 .prompt-actions {
-    position: absolute;
-    top: var(--spacing-sm);
-    right: var(--spacing-sm);
     display: flex;
-    gap: var(--spacing-xs);
+    gap: var(--spacing-sm);
+    justify-content: flex-end;
 }
 
 .prompt-actions button {
-    padding: var(--spacing-xs);
+    padding: var(--spacing-sm);
     font-size: var(--font-size-sm);
-    min-width: auto;
+    min-width: 75px;
 }
 
 .prompt-selector {

--- a/extension/style.css
+++ b/extension/style.css
@@ -1,7 +1,8 @@
 :root {
     /* Colors */
     --primary-color: #A700FF;
-    --secondary-color: #1d031f;
+    --secondary-color: #FF007a;
+    --background-color: #1d031f;
     --header-text-color: #fff;
     --text-color: #fff;
     --icon-color: #6c757d;
@@ -43,7 +44,7 @@
 /* Base Styles */
 body {
     font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background-color: var(--secondary-color);
+    background-color: var(--background-color);
     margin: 0;
     text-align: center;
     min-width: var(--container-width);
@@ -61,7 +62,7 @@ textarea, select, input {
     border: 2px solid var(--border-color);
     border-radius: var(--border-radius);
     font-size: var(--font-size-md);
-    background-color: var(--secondary-color);
+    background-color: var(--background-color);
     color: var(--text-color);
     font-family: inherit;
     line-height: 1.5;
@@ -75,7 +76,13 @@ select {
     background-repeat: no-repeat;
     background-position: right 8px center;
     background-size: 20px;
-    padding-right: 30px;
+    width: 100%;
+    padding: var(--spacing-sm) var(--spacing-md);
+    background-color: transparent;
+    color: var(--text-color);
+    border: 2px solid var(--secondary-color);
+    border-radius: var(--border-radius);
+    cursor: pointer;
 }
 
 textarea:focus, select:focus, input:focus {
@@ -104,7 +111,7 @@ textarea::-webkit-scrollbar,
 
 textarea::-webkit-scrollbar-track,
 .chat-messages::-webkit-scrollbar-track {
-    background: var(--secondary-color);
+    background: var(--background-color);
 }
 
 textarea::-webkit-scrollbar-thumb,
@@ -187,6 +194,7 @@ h3 {
     overflow: hidden;
 }
 
+select:hover,
 .btn:hover {
     background-color: transparent;
     box-shadow: 0 0 10px var(--button-color),
@@ -247,14 +255,16 @@ h3 {
 }
 
 /* Message Animation */
-@keyframes messagePopIn {
+@keyframes message-pop-in {
     0% {
         opacity: 0;
         transform: scale(0.8);
     }
+
     50% {
         transform: scale(1.02);
     }
+
     100% {
         opacity: 1;
         transform: scale(1);
@@ -262,9 +272,31 @@ h3 {
 }
 
 /* Apply animation to both messages and chat input container */
+.chat-input-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    gap: var(--spacing-md);
+    margin-top: var(--spacing-md);
+    transform-origin: bottom center;
+}
+
+.chat-input-container textarea {
+    flex-grow: 1;
+    margin: 0;
+    resize: vertical;
+    max-height: 6vh;
+}
+
+.chat-input-container .btn {
+    width: auto;
+    margin: 0;
+    align-self: flex-end;
+}
+
 .message,
 .chat-input-container:not(.hidden) {
-    animation: messagePopIn 0.25s ease-out forwards;
+    animation: message-pop-in 0.25s ease-out forwards;
     opacity: 0;
 }
 
@@ -290,28 +322,6 @@ h3 {
     margin-right: var(--spacing-lg);
     border-left: 4px solid var(--primary-color);
     transform-origin: top left;
-}
-
-.chat-input-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    gap: var(--spacing-md);
-    margin-top: var(--spacing-md);
-    transform-origin: bottom center;
-}
-
-.chat-input-container textarea {
-    flex-grow: 1;
-    margin: 0;
-    resize: vertical;
-    max-height: 6vh;
-}
-
-.chat-input-container .btn {
-    width: auto;
-    margin: 0;
-    align-self: flex-end;
 }
 
 .message.streaming {
@@ -391,7 +401,7 @@ h3 {
 }
 
 .markdown-body code {
-    background-color: rgb(215,0,126);
+    background-color: rgb(215 0 126);
     padding: var(--spacing-xs) var(--spacing-sm);
     border-radius: var(--border-radius);
     font-family: monospace;
@@ -617,12 +627,13 @@ hr {
 .prompt-selector select {
     width: 100%;
     padding: var(--spacing-sm) var(--spacing-md);
-    background-color: var(--message-bg-user);
+    background-color: transparent;
     color: var(--text-color);
-    border: 1px solid var(--border-color);
+    border: 2px solid var(--secondary-color);
     border-radius: var(--border-radius);
+    cursor: pointer;
 }
 
 .prompt-selector select option {
-    background-color: var(--secondary-color);
+    background-color: var(--background-color);
 }

--- a/extension/style.css
+++ b/extension/style.css
@@ -154,12 +154,20 @@ header,
     align-items: center;
 }
 
-h1 {
+h1, h2, h3 {
     font-size: var(--font-size-xl);
     margin: 0;
     color: var(--header-text-color);
     font-weight: var(--font-weight-semibold);
     letter-spacing: -0.01em;
+}
+
+h2 {
+    font-size: var(--font-size-lg);
+}
+
+h3 {
+    font-size: var(--font-size-md);
 }
 
 /* Button Styles */
@@ -564,6 +572,7 @@ hr {
     padding: var(--spacing-md);
     margin: var(--spacing-sm) 0;
     border-radius: var(--border-radius);
+    color: var(--text-color);
     position: relative;
 }
 

--- a/extension/style.css
+++ b/extension/style.css
@@ -587,6 +587,9 @@ hr {
     color: var(--text-color);
     font-weight: var(--font-weight-semibold);
     margin-bottom: var(--spacing-xs);
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 .prompt-content {

--- a/extension/style.css
+++ b/extension/style.css
@@ -540,3 +540,72 @@ hr {
     flex: 1;
     max-width: 45%;
 }
+
+.prompt-manager {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+}
+
+.prompt-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.saved-prompts {
+    margin-top: var(--spacing-md);
+    text-align: left;
+}
+
+.prompt-item {
+    background: var(--message-bg-user);
+    padding: var(--spacing-md);
+    margin: var(--spacing-sm) 0;
+    border-radius: var(--border-radius);
+    position: relative;
+}
+
+.prompt-pattern {
+    font-size: var(--font-size-sm);
+    color: var(--primary-color);
+    margin-bottom: var(--spacing-xs);
+}
+
+.prompt-content {
+    font-size: var(--font-size-sm);
+    white-space: pre-wrap;
+}
+
+.prompt-actions {
+    position: absolute;
+    top: var(--spacing-sm);
+    right: var(--spacing-sm);
+    display: flex;
+    gap: var(--spacing-xs);
+}
+
+.prompt-actions button {
+    padding: var(--spacing-xs);
+    font-size: var(--font-size-sm);
+    min-width: auto;
+}
+
+.prompt-selector {
+    width: 100%;
+    margin-bottom: var(--spacing-sm);
+}
+
+.prompt-selector select {
+    width: 100%;
+    padding: var(--spacing-sm) var(--spacing-md);
+    background-color: var(--message-bg-user);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+}
+
+.prompt-selector select option {
+    background-color: var(--secondary-color);
+}

--- a/extension/style.css
+++ b/extension/style.css
@@ -553,13 +553,19 @@ hr {
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-md);
+    gap: var(--spacing-lg);
 }
 
 .prompt-form {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-sm);
+    gap: var(--spacing-lg);
+}
+
+.prompt-url-input {
+    display: grid;
+    grid-template-columns: 1fr 0.3fr;
+    gap: var(--spacing-lg);
 }
 
 .saved-prompts {

--- a/extension/templates.js
+++ b/extension/templates.js
@@ -45,6 +45,16 @@ const templates = {
                 <div id="prompts-list"></div>
             </div>
         </div>
+    `,
+    promptItem: `
+        <div class="prompt-item">
+            <div class="prompt-pattern">{{pattern}}</div>
+            <div class="prompt-content">{{content}}</div>
+            <div class="prompt-actions">
+                <button class="btn" data-action="edit" data-pattern="{{pattern}}">Edit</button>
+                <button class="btn danger-btn" data-action="delete" data-pattern="{{pattern}}">Delete</button>
+            </div>
+        </div>
     `
 };
 

--- a/extension/templates.js
+++ b/extension/templates.js
@@ -36,7 +36,7 @@ const templates = {
     promptManager: `
         <div class="prompt-manager">
             <div class="prompt-form">
-                <input type="text" id="prompt-pattern" placeholder="URL pattern (e.g., reddit.com/user/*)">
+                <input type="text" id="prompt-pattern" placeholder="URL pattern (e.g., reddit.com/user)">
                 <textarea id="prompt-content" rows="3" placeholder="Enter prompt for this URL pattern"></textarea>
                 <button id="save-prompt" class="btn">Save Prompt</button>
             </div>

--- a/extension/templates.js
+++ b/extension/templates.js
@@ -36,9 +36,11 @@ const templates = {
     promptManager: `
         <div class="prompt-manager">
             <div class="prompt-form">
-                <input type="text" id="prompt-pattern" placeholder="URL pattern (e.g., reddit.com/user)">
-                <textarea id="prompt-content" rows="3" placeholder="Enter prompt for this URL pattern"></textarea>
-                <button id="save-prompt" class="btn">Save Prompt</button>
+                <div class="prompt-url-input">
+                    <input type="text" id="prompt-pattern" placeholder="URL pattern (e.g., reddit.com/user)">
+                    <button id="use-current-url" class="btn">Get URL</button>
+                </div>
+                <textarea id="prompt-content" rows="6" placeholder="Enter prompt for this URL pattern"></textarea>
             </div>
             <div class="saved-prompts">
                 <h3>Saved Prompts</h3>

--- a/extension/templates.js
+++ b/extension/templates.js
@@ -41,6 +41,7 @@ const templates = {
                     <button id="use-current-url" class="btn">Get URL</button>
                 </div>
                 <textarea id="prompt-content" rows="6" placeholder="Enter prompt for this URL pattern"></textarea>
+                <button id="save-prompt" class="btn">Save</button>
             </div>
             <div class="saved-prompts">
                 <h3>Saved Prompts</h3>
@@ -50,10 +51,10 @@ const templates = {
     `,
     promptItem: `
         <div class="prompt-item">
-            <div class="prompt-pattern">{{pattern}}</div>
+            <div class="prompt-pattern" title="{{pattern}}">{{pattern}}</div>
             <div class="prompt-content">{{content}}</div>
             <div class="prompt-actions">
-                <button class="btn" data-action="edit" data-pattern="{{pattern}}">Edit</button>
+                <button class="btn" data-action="edit" data-pattern="{{pattern}}" data-content="{{content}}">Edit</button>
                 <button class="btn danger-btn" data-action="delete" data-pattern="{{pattern}}">Delete</button>
             </div>
         </div>

--- a/extension/templates.js
+++ b/extension/templates.js
@@ -32,6 +32,19 @@ const templates = {
                 </div>
             </div>
         </div>
+    `,
+    promptManager: `
+        <div class="prompt-manager">
+            <div class="prompt-form">
+                <input type="text" id="prompt-pattern" placeholder="URL pattern (e.g., reddit.com/user/*)">
+                <textarea id="prompt-content" rows="3" placeholder="Enter prompt for this URL pattern"></textarea>
+                <button id="save-prompt" class="btn">Save Prompt</button>
+            </div>
+            <div class="saved-prompts">
+                <h3>Saved Prompts</h3>
+                <div id="prompts-list"></div>
+            </div>
+        </div>
     `
 };
 


### PR DESCRIPTION
## Summary

This solves for isse #25 

* Added the ability to save prompts based on the URL we're at. The extension will match the closes to the URL for example:
    - If we have two saved prompts, one for `reddit.com` and one for `reddit.com/user` and we go to `reddit.com/user/loktar00`, the prompt that auto loads will be for `reddit.com/user`. 
* Added button for users to easily get the URL they're currently on in order to create a prompt for the page.
* Left all youtube transcript functionality untouched so that still works as it should.
* Modified styles and templates
* Added functionality to delete and edit existing saved prompts

### Outstanding issues

Not really an "issue" but to modify the default prompt you still need to go to the settings, we should resolve this and allow users to edit the default prompt from the prompt management page.

