### PR TITLE
Added token summary and wild card support for URLs

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -673,17 +673,78 @@ function initializeUI() {
 const promptManager = {
     async savePrompt(pattern, prompt) {
         const { savedPrompts = {} } = await chrome.storage.sync.get('savedPrompts');
-        // Remove www. from pattern if present
+        // Remove www. and clean pattern
         const cleanPattern = pattern.replace(/^www\./, '');
         savedPrompts[cleanPattern] = prompt;
         await chrome.storage.sync.set({ savedPrompts });
     },
 
+    patternToRegex(pattern) {
+        // Split into path and query parts
+        const [pathPart, queryPart] = pattern.split('?');
+
+        // Build path regex
+        let pathRegex = '^' + pathPart
+            .replace(/[.+?^${}()|[\]\\]/g, '\\$&') // Escape special regex chars except *
+            .replace(/\*/g, '[^?]*');              // * matches anything except ?
+
+        // Add query parameters if they exist
+        if (queryPart) {
+            pathRegex += '\\?';
+            const queryParams = queryPart.split('&').map(param => {
+                return param.replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+                    .replace(/\*/g, '[^&]*');
+            });
+
+            // Allow query parameters in any order
+            pathRegex += queryParams
+                .map(param => `(?=.*${param})`)
+                .join('');
+
+            pathRegex += '[^#]*';  // Match rest of query string until fragment
+        }
+
+        return new RegExp(pathRegex);
+    },
+
     findBestMatchForUrl(url, patterns) {
-        // Sort patterns by length (longest first) and find first match
-        return patterns
-            .sort((a, b) => b.length - a.length)
-            .find(pattern => url.includes(pattern));
+        // Clean the URL for matching
+        const cleanUrl = url.replace(/^www\./, '');
+
+        // Convert patterns to regex and find matches
+        const matches = patterns
+            .map(pattern => ({
+                pattern,
+                regex: this.patternToRegex(pattern),
+                specificity: this.calculateSpecificity(pattern)
+            }))
+            .filter(({ regex }) => {
+                try {
+                    return regex.test(cleanUrl);
+                } catch (e) {
+                    console.error('Regex error for pattern:', pattern, e);
+                    return false;
+                }
+            })
+            .sort((a, b) => {
+                // Sort by specificity first
+                const specificityDiff = b.specificity - a.specificity;
+                if (specificityDiff !== 0) return specificityDiff;
+
+                // If same specificity, prefer longer pattern
+                return b.pattern.length - a.pattern.length;
+            });
+
+        return matches[0]?.pattern;
+    },
+
+    calculateSpecificity(pattern) {
+        // Count non-wildcard segments
+        const segments = pattern.split('/');
+        const queryParts = pattern.split('?')[1]?.split('&') || [];
+
+        return segments.filter(s => s !== '*').length +
+               queryParts.filter(p => p !== '*').length;
     }
 };
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -533,7 +533,7 @@ const handlers = {
             elements.formattedSummary.innerHTML = `
                 <div class="message user-message">
                     <div>
-                        ${markdownToHtml(transcript)}
+                        ${markdownToHtml(`${systemPromptArea.value}\n\n${transcript}`)}
                     </div>
                 </div>
             `;

--- a/extension/style.css
+++ b/extension/style.css
@@ -624,7 +624,7 @@ hr {
     margin-bottom: var(--spacing-sm);
 }
 
-.prompt-selector select {
+select {
     width: 100%;
     padding: var(--spacing-sm) var(--spacing-md);
     background-color: transparent;
@@ -634,6 +634,18 @@ hr {
     cursor: pointer;
 }
 
-.prompt-selector select option {
+select option {
     background-color: var(--background-color);
+}
+
+.token-display {
+    font-size: var(--font-size-sm);
+    color: var(--text-color);
+    opacity: 0.8;
+    text-align: right;
+    margin: var(--spacing-sm) 0;
+}
+
+.token-display.token-warning {
+    color: var(--streaming-color);
 }

--- a/extension/templates.js
+++ b/extension/templates.js
@@ -17,6 +17,7 @@ const templates = {
                             <div></div>
                             <div></div>
                         </div>
+                        <div class="token-display"></div>
                         <div class="button-group loading-controls">
                             <button id="cancel-generation" class="btn">← Back</button>
                             <button id="stop-generation" class="btn danger-btn">Stop</button>
@@ -24,6 +25,7 @@ const templates = {
                     </div>
                     <div class="chat-input-container hidden">
                         <textarea id="chat-input" rows="3" placeholder="Ask a question about the transcript..."></textarea>
+                        <div class="token-display"></div>
                         <div class="button-group">
                             <button id="back-to-transcript" class="btn">← Back</button>
                             <button id="send-message" class="btn">Send</button>


### PR DESCRIPTION
Partial work complete for #31 

* Added token summary along with context display
* Added wildcard matching for URLs, for example to summarize boardgamegeek reviews you can use :

`https://boardgamegeek.com/boardgame/*/ratings?rated=1&comment=1`

Which will match this for example:
`https://boardgamegeek.com/boardgame/42776/gears-of-war-the-board-game/ratings?rated=1&comment=1&pageid=1`

Making it easier to quickly gather data from similar pages.