### PR TITLE
Fix YouTube transcript extraction for new layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Gnomly** — a Chrome extension (Manifest v3) that extracts content from YouTube videos (transcripts) and webpages, then sends it to AI models (Ollama or DeepSeek) for analysis via a streaming chat interface. The UI renders as a browser side panel.
+
+## Commands
+
+```bash
+npm run dev        # Start Vite dev server (opens browser)
+npm run build      # TypeScript check + Vite production build → dist/
+npm run lint       # ESLint check
+npm run lint:fix   # ESLint auto-fix
+npm test           # Run Vitest (watch mode)
+npx vitest run     # Run tests once (CI-friendly)
+```
+
+To load the built extension: build, then load `dist/` as an unpacked extension in `chrome://extensions`.
+
+## Architecture
+
+**React + TypeScript Chrome extension** built with Vite. The Vite root is `src/` (not the repo root), and `public/` contains Chrome extension assets (manifest, service worker, content scripts) that get copied into `dist/` at build time.
+
+### Data Flow
+
+User selects content source (YouTube/webpage/custom) → prompt auto-matched by URL pattern → content extracted via Chrome scripting API → optionally chunked for large content → streamed to AI provider → response rendered as markdown in chat UI.
+
+### Key Layers
+
+- **Views** (`src/views/`) — page-level components: `Home` (content input + prompt selection), `Summary` (chat interface + streaming), `Settings` (provider config), `PromptManager` (CRUD for URL-matched prompts)
+- **Stores** (`src/stores/`) — Zustand stores: `Summary.ts` (content/prompt/chunk state), `SavedPrompts.ts` (prompt persistence)
+- **Utils** (`src/utils/`) — core logic: `chat.ts` (streaming + token counting + chunking), `content.ts` (YouTube transcript + webpage extraction), `url.ts` (wildcard URL pattern matching), `prompts.ts` (prompt CRUD), `markdown.ts` (MD→HTML), `storage.ts` (Chrome storage abstraction with localStorage fallback)
+- **Configs** (`src/Configs/ModelProviders.ts`) — provider definitions for Ollama and DeepSeek (URLs, endpoints, defaults, token limits)
+
+### Routing
+
+Uses `wouter` for client-side routing. Routes defined in `App.tsx`.
+
+### Path Alias
+
+`@/*` maps to `src/*` (configured in both tsconfig and vite).
+
+## Code Style
+
+- **4-space indentation** (enforced by ESLint)
+- `react-hooks/exhaustive-deps` is intentionally disabled
+- TypeScript strict mode with `noUnusedLocals` and `noUnusedParameters`

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -160,10 +160,36 @@ export async function fetchYouTubeTranscript() {
                                     attempts++;
 
                                     // Look for transcript panel elements
-                                    const transcriptPanel = document.querySelector('ytd-transcript-segment-list-renderer, #transcript, [data-target-id="engagement-panel-transcript"]');
+                                    const transcriptPanel = document.querySelector(
+                                        'ytd-macro-markers-list-renderer, ' +
+                                        'ytd-transcript-segment-list-renderer, ' +
+                                        '#transcript, ' +
+                                        '[data-target-id="engagement-panel-transcript"]'
+                                    );
 
                                     if (transcriptPanel) {
-                                        // Try different selectors for transcript segments
+                                        // Try new YouTube layout first (transcript-segment-view-model)
+                                        const newSegments = transcriptPanel.querySelectorAll('transcript-segment-view-model');
+
+                                        if (newSegments.length > 0) {
+                                            const transcriptTexts: string[] = [];
+
+                                            newSegments.forEach((segment) => {
+                                                const timestamp = segment.querySelector('.ytwTranscriptSegmentViewModelTimestamp')?.textContent?.trim();
+                                                const text = segment.querySelector('.yt-core-attributed-string')?.textContent?.trim();
+
+                                                if (timestamp && text) {
+                                                    transcriptTexts.push(`${timestamp} - ${text}`);
+                                                }
+                                            });
+
+                                            if (transcriptTexts.length > 0) {
+                                                resolve(transcriptTexts.join('\n'));
+                                                return;
+                                            }
+                                        }
+
+                                        // Fall back to old layout selectors
                                         const transcriptSegments =
                                             transcriptPanel.querySelectorAll('ytd-transcript-segment-renderer') ||
                                             transcriptPanel.querySelectorAll('[data-segment-start-time]') ||
@@ -171,7 +197,6 @@ export async function fetchYouTubeTranscript() {
                                             transcriptPanel.querySelectorAll('span');
 
                                         if (transcriptSegments.length > 0) {
-                                            // Extract text from segments
                                             const transcriptTexts: string[] = [];
 
                                             transcriptSegments.forEach((segment) => {


### PR DESCRIPTION
## Summary
- YouTube updated their transcript DOM structure to use `transcript-segment-view-model` elements within `ytd-macro-markers-list-renderer`
- Updated panel selector to target `ytd-macro-markers-list-renderer` so transcripts are extracted across all chapters, not just the first
- Each segment now extracts timestamp + text (e.g., `2:27 - Start making your projects.`)
- Old layout selectors retained as fallbacks

## Test plan
- [ ] Load extension and open a YouTube video with transcripts
- [ ] Verify transcript extracts all chapters, not just the first
- [ ] Verify each line includes timestamp and text
- [ ] Test on a video without chapters to confirm fallback works