### PR TITLE
Add IndexedDB storage for prompts & conversations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import { Route, Switch, Link } from "wouter";
-import { IoNewspaperOutline, IoSettingsOutline  } from "react-icons/io5";
+import { IoNewspaperOutline, IoSettingsOutline, IoChatbubblesOutline  } from "react-icons/io5";
 import { ToastContainer } from 'react-toastify';
 import { Home } from "./views/Home/Home.tsx";
 import { Settings } from "./views/Settings";
 import { PromptManager } from "./views/PromptManager/PromptManager";
 import { Summary } from "./views/Summary/Summary.tsx";
+import { ConversationsView } from "./views/Home/ConversationsView.tsx";
 
 export const App = () =>  (
     <body>
@@ -16,6 +17,9 @@ export const App = () =>  (
                     </h1>
                 </Link>
                 <div className="header-buttons">
+                    <Link to="/conversations">
+                        <button className="settings-btn" title="Recent Conversations"><IoChatbubblesOutline size={24} /></button>
+                    </Link>
                     <Link to="/prompt-manager">
                         <button id="manage-prompts" className="settings-btn" title="Manage Prompts"><IoNewspaperOutline size={24} /></button>
                     </Link>
@@ -34,6 +38,9 @@ export const App = () =>  (
                     </Route>
                     <Route path="/prompt-manager">
                         <PromptManager />
+                    </Route>
+                    <Route path="/conversations">
+                        <ConversationsView />
                     </Route>
                     <Route path="/summary">
                         <Summary />

--- a/src/components/PathSelector.tsx
+++ b/src/components/PathSelector.tsx
@@ -1,10 +1,12 @@
 import { useState, useCallback } from 'react';
+import { IoScanOutline } from "react-icons/io5";
 
 interface PathSelectorProps {
     onPathSelected: (selector: string) => void;
+    compact?: boolean;
 }
 
-export const PathSelector = ({ onPathSelected }: PathSelectorProps) => {
+export const PathSelector = ({ onPathSelected, compact }: PathSelectorProps) => {
     const [isSelecting, setIsSelecting] = useState(false);
 
     const startSelection = useCallback(async () => {
@@ -58,10 +60,14 @@ export const PathSelector = ({ onPathSelected }: PathSelectorProps) => {
 
     return (
         <button
-            className={`btn ${isSelecting ? 'selecting' : ''}`}
+            className={`btn ${isSelecting ? 'selecting' : ''} ${compact ? 'icon-btn' : ''}`}
             onClick={startSelection}
+            title="Select Content"
             disabled={isSelecting}>
-            {isSelecting ? 'Cancel Selection' : 'Select Content'}
+            {compact
+                ? <IoScanOutline size={18} />
+                : isSelecting ? 'Cancel Selection' : 'Select Content'
+            }
         </button>
     );
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 export const CONSTANTS = {
     DEFAULT_SYSTEM_PROMPT: "Please summarize this content, it may be a video transcript or the contents of a webpage. You may receive json, and css please focus on the content of the page. It is very important to remain unbiased. Highlight important parts of the content however keep it relatively short so we're able to get the overall idea of the content, highlight any important areas that need focus. For a top X list always list the items in order.",
+    TITLE_GENERATION_PROMPT: "Generate a short title (5-8 words max) for this conversation. Return ONLY the title, nothing else.",
     API: {
         DEFAULT_AI_URL: "http://localhost:11434",
         DEFAULT_CHUNK_SUMMARY_PROMPT: `

--- a/src/index.css
+++ b/src/index.css
@@ -335,6 +335,17 @@ select:hover,
   gap: var(--spacing-md);
 }
 
+.chat-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+}
+
+.icon-btn {
+  padding: var(--spacing-sm) var(--spacing-md);
+  min-width: unset;
+}
+
 .message {
   animation: message-pop-in 0.25s ease-out forwards;
   opacity: 0;
@@ -791,4 +802,118 @@ select option {
   color: var(--streaming-color);
   margin: var(--spacing-sm) 0;
   text-align: center;
+}
+
+/* Conversations View */
+.conversations-view {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.conversations-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+/* Conversation List */
+.conversation-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.conversation-search {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.conversation-item {
+  background: var(--message-bg-ai);
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius);
+  color: var(--text-color);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  transition: all var(--transition-speed);
+}
+
+.conversation-item:hover {
+  box-shadow: 0 0 8px var(--ai-accent-color);
+}
+
+.conversation-item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.conversation-title {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.conversation-meta {
+  font-size: var(--font-size-xs);
+  color: var(--text-color);
+  opacity: 0.6;
+  margin-top: var(--spacing-xs);
+}
+
+.conversation-delete {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  opacity: 0.4;
+  cursor: pointer;
+  padding: var(--spacing-sm);
+  transition: opacity var(--transition-speed);
+  flex-shrink: 0;
+}
+
+.conversation-delete:hover {
+  opacity: 1;
+  color: var(--secondary-color);
+}
+
+.conversation-list-loading,
+.conversation-list-empty {
+  font-size: var(--font-size-sm);
+  color: var(--text-color);
+  opacity: 0.6;
+  text-align: center;
+  padding: var(--spacing-md);
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-sm);
+}
+
+.pagination .btn {
+  padding: var(--spacing-sm) var(--spacing-md);
+  min-width: 32px;
+  font-size: var(--font-size-sm);
+}
+
+.pagination .btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.pagination-info {
+  font-size: var(--font-size-sm);
+  color: var(--text-color);
+  opacity: 0.8;
 }

--- a/src/stores/Conversations.ts
+++ b/src/stores/Conversations.ts
@@ -1,0 +1,160 @@
+import { create } from 'zustand';
+import { Message, Conversation, ConversationSummary } from '@/views/Summary/types';
+import {
+    dbSaveConversation,
+    dbGetConversation,
+    dbUpdateConversationMessages,
+    dbUpdateConversationTitle,
+    dbDeleteConversation,
+    dbGetConversations,
+} from '@/utils/db';
+
+interface ConversationsState {
+    // List
+    conversations: ConversationSummary[];
+    totalCount: number;
+    currentPage: number;
+    pageSize: number;
+    searchQuery: string;
+    isLoading: boolean;
+
+    // Active conversation
+    activeConversationId: string | null;
+    activeMessages: Message[];
+
+    // List actions
+    loadConversations: () => Promise<void>;
+    setPage: (page: number) => void;
+    setSearchQuery: (query: string) => void;
+    deleteConversation: (id: string) => Promise<void>;
+
+    // Active conversation actions
+    startNewConversation: (provider: string, model: string, systemPrompt?: string, sourceUrl?: string) => string;
+    loadConversation: (id: string) => Promise<void>;
+    addMessage: (message: Message) => Promise<void>;
+    updateTitle: (title: string) => Promise<void>;
+    clearActiveConversation: () => void;
+}
+
+export const useConversationsStore = create<ConversationsState>((set, get) => ({
+    conversations: [],
+    totalCount: 0,
+    currentPage: 1,
+    pageSize: 10,
+    searchQuery: '',
+    isLoading: false,
+
+    activeConversationId: null,
+    activeMessages: [],
+
+    loadConversations: async () => {
+        const { currentPage, pageSize, searchQuery } = get();
+        set({ isLoading: true });
+        try {
+            const result = await dbGetConversations({
+                page: currentPage,
+                pageSize,
+                search: searchQuery || undefined,
+            });
+            set({
+                conversations: result.items,
+                totalCount: result.total,
+                isLoading: false,
+            });
+        } catch (error) {
+            console.error('Failed to load conversations:', error);
+            set({ isLoading: false });
+        }
+    },
+
+    setPage: (page: number) => {
+        set({ currentPage: page });
+        get().loadConversations();
+    },
+
+    setSearchQuery: (query: string) => {
+        set({ searchQuery: query, currentPage: 1 });
+        get().loadConversations();
+    },
+
+    deleteConversation: async (id: string) => {
+        try {
+            await dbDeleteConversation(id);
+            const { activeConversationId } = get();
+            if (activeConversationId === id) {
+                set({ activeConversationId: null, activeMessages: [] });
+            }
+            await get().loadConversations();
+        } catch (error) {
+            console.error('Failed to delete conversation:', error);
+        }
+    },
+
+    startNewConversation: (provider: string, model: string, systemPrompt?: string, sourceUrl?: string) => {
+        const id = crypto.randomUUID();
+        const now = Date.now();
+        const conversation: Conversation = {
+            id,
+            title: 'New conversation',
+            messages: [],
+            createdAt: now,
+            updatedAt: now,
+            provider,
+            model,
+            systemPrompt,
+            sourceUrl,
+        };
+
+        set({ activeConversationId: id, activeMessages: [] });
+
+        // Save to IndexedDB in background
+        dbSaveConversation(conversation).catch((err) =>
+            console.error('Failed to save new conversation:', err)
+        );
+
+        return id;
+    },
+
+    loadConversation: async (id: string) => {
+        try {
+            const conversation = await dbGetConversation(id);
+            if (conversation) {
+                set({
+                    activeConversationId: conversation.id,
+                    activeMessages: conversation.messages,
+                });
+            }
+        } catch (error) {
+            console.error('Failed to load conversation:', error);
+        }
+    },
+
+    addMessage: async (message: Message) => {
+        const { activeConversationId, activeMessages } = get();
+        if (!activeConversationId) return;
+
+        const updated = [...activeMessages, message];
+        set({ activeMessages: updated });
+
+        try {
+            await dbUpdateConversationMessages(activeConversationId, updated);
+        } catch (error) {
+            console.error('Failed to persist message:', error);
+        }
+    },
+
+    updateTitle: async (title: string) => {
+        const { activeConversationId } = get();
+        if (!activeConversationId) return;
+
+        try {
+            await dbUpdateConversationTitle(activeConversationId, title);
+        } catch (error) {
+            console.error('Failed to update conversation title:', error);
+        }
+    },
+
+    clearActiveConversation: () => {
+        set({ activeConversationId: null, activeMessages: [] });
+    },
+}));

--- a/src/stores/SavedPrompts.ts
+++ b/src/stores/SavedPrompts.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { Prompt, getPrompts, savePrompt } from '@/utils/prompts';
-import { storage } from '@/utils/storage';
+import { dbDeletePrompt, dbSetDefaultPrompt } from '@/utils/db';
+import { migratePromptsToIndexedDB } from '@/utils/migration';
 import { CONSTANTS } from '@/constants';
 
 interface PromptManagerState {
@@ -9,8 +10,8 @@ interface PromptManagerState {
     error: string | null;
     initializePrompts: () => Promise<void>;
     addPrompt: (prompt: Prompt) => Promise<void>;
-    deletePrompt: (pattern: string) => Promise<void>;
-    setDefaultPrompt: (pattern: string) => Promise<void>;
+    deletePrompt: (id: string) => Promise<void>;
+    setDefaultPrompt: (id: string) => Promise<void>;
 }
 
 export const usePromptManagerStore = create<PromptManagerState>((set) => ({
@@ -21,6 +22,10 @@ export const usePromptManagerStore = create<PromptManagerState>((set) => ({
     initializePrompts: async () => {
         try {
             set({ isLoading: true, error: null });
+
+            // Migrate from chrome.storage.sync to IndexedDB on first run
+            await migratePromptsToIndexedDB();
+
             let savedPrompts = await getPrompts();
 
             // If no prompts exist, create the default one
@@ -57,12 +62,9 @@ export const usePromptManagerStore = create<PromptManagerState>((set) => ({
         }
     },
 
-    deletePrompt: async (pattern: string) => {
+    deletePrompt: async (id: string) => {
         try {
-            const result = await storage.sync.get('savedPrompts');
-            const savedPrompts = result.savedPrompts || {};
-            delete savedPrompts[pattern];
-            await storage.sync.set({ savedPrompts });
+            await dbDeletePrompt(id);
 
             // Refresh prompts after deletion
             const updatedPrompts = await getPrompts();
@@ -72,24 +74,9 @@ export const usePromptManagerStore = create<PromptManagerState>((set) => ({
         }
     },
 
-    setDefaultPrompt: async (pattern: string) => {
+    setDefaultPrompt: async (id: string) => {
         try {
-            const result = await storage.sync.get('savedPrompts');
-            const savedPrompts = result.savedPrompts || {};
-
-            // Remove default flag from all prompts
-            Object.keys(savedPrompts).forEach(key => {
-                if (savedPrompts[key].isDefault) {
-                    savedPrompts[key].isDefault = false;
-                }
-            });
-
-            // Set new default
-            if (savedPrompts[pattern]) {
-                savedPrompts[pattern].isDefault = true;
-            }
-
-            await storage.sync.set({ savedPrompts });
+            await dbSetDefaultPrompt(id);
 
             // Refresh prompts after updating
             const updatedPrompts = await getPrompts();

--- a/src/stores/Summary.ts
+++ b/src/stores/Summary.ts
@@ -6,8 +6,10 @@ interface SummaryState {
     content: string;
     prompt: string;
     enableChunking: boolean;
+    sourceUrl: string;
     setContent: (content: string) => void;
     setPrompt: (prompt: string) => void;
+    setSourceUrl: (url: string) => void;
     setEnableChunking: (enabled: boolean) => Promise<void>;
     initializeChunkSetting: () => Promise<void>;
 }
@@ -16,9 +18,11 @@ export const useSummaryStore = create<SummaryState>((set) => ({
     content: '',
     prompt: '',
     enableChunking: false,
+    sourceUrl: '',
 
     setContent: (content: string) => set({ content }),
     setPrompt: (prompt: string) => set({ prompt }),
+    setSourceUrl: (url: string) => set({ sourceUrl: url }),
 
     setEnableChunking: async (enabled: boolean) => {
         try {

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -291,6 +291,59 @@ export async function chunkAndSummarize(
     return chunkSummaries.join('\n\n');
 }
 
+export async function generateConversationTitle(
+    settings: ModelConfig,
+    firstUserMessage: string,
+    firstAssistantResponse: string
+): Promise<string> {
+    const truncatedUser = firstUserMessage.slice(0, 200);
+    const truncatedAssistant = firstAssistantResponse.slice(0, 200);
+
+    const messages = [
+        { role: 'system', content: CONSTANTS.TITLE_GENERATION_PROMPT },
+        { role: 'user', content: `User: ${truncatedUser}\n\nAssistant: ${truncatedAssistant}` },
+    ];
+
+    if (settings.provider === 'Deepseek') {
+        const response = await fetch(`${settings.url}/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${settings.api_key}`,
+            },
+            body: JSON.stringify({
+                model: settings.model,
+                messages,
+                stream: false,
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Title generation failed: ${response.status}`);
+        }
+
+        const data = await response.json();
+        return data.choices[0]?.message?.content?.trim() || 'Untitled conversation';
+    } else {
+        const response = await fetch(`${settings.url}/api/chat`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                model: settings.model,
+                messages,
+                stream: false,
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Title generation failed: ${response.status}`);
+        }
+
+        const data = await response.json();
+        return data.message?.content?.trim() || 'Untitled conversation';
+    }
+}
+
 export function formatSize(bytes: number): string {
     if (bytes === 0) {
         return '0 B';

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,0 +1,239 @@
+import { Prompt } from './prompts';
+import { Conversation, ConversationSummary } from '@/views/Summary/types';
+import { Message } from '@/views/Summary/types';
+
+const DB_NAME = 'gnomly-db';
+const DB_VERSION = 1;
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function getDB(): Promise<IDBDatabase> {
+    if (!dbPromise) {
+        dbPromise = new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+            request.onupgradeneeded = (event) => {
+                const db = (event.target as IDBOpenDBRequest).result;
+
+                if (!db.objectStoreNames.contains('prompts')) {
+                    const promptStore = db.createObjectStore('prompts', { keyPath: 'id' });
+                    promptStore.createIndex('pattern', 'pattern', { unique: true });
+                    promptStore.createIndex('isDefault', 'isDefault', { unique: false });
+                }
+
+                if (!db.objectStoreNames.contains('conversations')) {
+                    const convStore = db.createObjectStore('conversations', { keyPath: 'id' });
+                    convStore.createIndex('title', 'title', { unique: false });
+                    convStore.createIndex('updatedAt', 'updatedAt', { unique: false });
+                }
+            };
+
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+    return dbPromise;
+}
+
+// --- Prompt functions ---
+
+export async function dbGetAllPrompts(): Promise<Prompt[]> {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction('prompts', 'readonly');
+        const store = tx.objectStore('prompts');
+        const request = store.getAll();
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+export async function dbSavePrompt(prompt: Prompt): Promise<void> {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction('prompts', 'readwrite');
+        const store = tx.objectStore('prompts');
+
+        if (prompt.isDefault) {
+            // Remove isDefault from all other prompts
+            const cursorReq = store.openCursor();
+            cursorReq.onsuccess = () => {
+                const cursor = cursorReq.result;
+                if (cursor) {
+                    const value = cursor.value;
+                    if (value.isDefault && value.id !== prompt.id) {
+                        value.isDefault = false;
+                        cursor.update(value);
+                    }
+                    cursor.continue();
+                } else {
+                    // All existing defaults cleared, now save the prompt
+                    const putReq = store.put(prompt);
+                    putReq.onerror = () => reject(putReq.error);
+                }
+            };
+        } else {
+            store.put(prompt);
+        }
+
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+export async function dbDeletePrompt(id: string): Promise<void> {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction('prompts', 'readwrite');
+        const store = tx.objectStore('prompts');
+        store.delete(id);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+export async function dbSetDefaultPrompt(id: string): Promise<void> {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction('prompts', 'readwrite');
+        const store = tx.objectStore('prompts');
+
+        const cursorReq = store.openCursor();
+        cursorReq.onsuccess = () => {
+            const cursor = cursorReq.result;
+            if (cursor) {
+                const value = cursor.value;
+                const shouldBeDefault = value.id === id;
+                if (value.isDefault !== shouldBeDefault) {
+                    value.isDefault = shouldBeDefault;
+                    cursor.update(value);
+                }
+                cursor.continue();
+            }
+        };
+
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+// --- Conversation functions ---
+
+export async function dbSaveConversation(conversation: Conversation): Promise<void> {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction('conversations', 'readwrite');
+        const store = tx.objectStore('conversations');
+        store.put(conversation);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+export async function dbGetConversation(id: string): Promise<Conversation | undefined> {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction('conversations', 'readonly');
+        const store = tx.objectStore('conversations');
+        const request = store.get(id);
+        request.onsuccess = () => resolve(request.result || undefined);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+export async function dbUpdateConversationMessages(id: string, messages: Message[]): Promise<void> {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction('conversations', 'readwrite');
+        const store = tx.objectStore('conversations');
+        const getReq = store.get(id);
+
+        getReq.onsuccess = () => {
+            const conversation = getReq.result;
+            if (conversation) {
+                conversation.messages = messages;
+                conversation.updatedAt = Date.now();
+                store.put(conversation);
+            }
+        };
+
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+export async function dbUpdateConversationTitle(id: string, title: string): Promise<void> {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction('conversations', 'readwrite');
+        const store = tx.objectStore('conversations');
+        const getReq = store.get(id);
+
+        getReq.onsuccess = () => {
+            const conversation = getReq.result;
+            if (conversation) {
+                conversation.title = title;
+                conversation.updatedAt = Date.now();
+                store.put(conversation);
+            }
+        };
+
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+export async function dbDeleteConversation(id: string): Promise<void> {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction('conversations', 'readwrite');
+        const store = tx.objectStore('conversations');
+        store.delete(id);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+export async function dbGetConversations(opts: {
+    page: number;
+    pageSize: number;
+    search?: string;
+}): Promise<{ items: ConversationSummary[]; total: number }> {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction('conversations', 'readonly');
+        const store = tx.objectStore('conversations');
+        const index = store.index('updatedAt');
+
+        const allItems: ConversationSummary[] = [];
+        const request = index.openCursor(null, 'prev'); // most recent first
+
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (cursor) {
+                const conv = cursor.value as Conversation;
+                const searchLower = opts.search?.toLowerCase();
+
+                if (!searchLower || conv.title.toLowerCase().includes(searchLower)) {
+                    allItems.push({
+                        id: conv.id,
+                        title: conv.title,
+                        createdAt: conv.createdAt,
+                        updatedAt: conv.updatedAt,
+                        provider: conv.provider,
+                        model: conv.model,
+                        messageCount: conv.messages.length,
+                    });
+                }
+                cursor.continue();
+            }
+        };
+
+        tx.oncomplete = () => {
+            const start = (opts.page - 1) * opts.pageSize;
+            const items = allItems.slice(start, start + opts.pageSize);
+            resolve({ items, total: allItems.length });
+        };
+        tx.onerror = () => reject(tx.error);
+    });
+}

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -1,0 +1,42 @@
+import { storage } from './storage';
+import { dbSavePrompt } from './db';
+import { Prompt } from './prompts';
+
+const MIGRATION_FLAG = 'gnomly-prompts-migrated';
+
+export async function migratePromptsToIndexedDB(): Promise<void> {
+    if (localStorage.getItem(MIGRATION_FLAG)) {
+        return;
+    }
+
+    try {
+        const result = await storage.sync.get('savedPrompts') as {
+            savedPrompts?: Record<string, {
+                content: string;
+                isDefault: boolean;
+                id: string;
+                name: string;
+                pattern: string;
+                selector?: string;
+            }>;
+        };
+
+        const savedPrompts = result.savedPrompts || {};
+
+        for (const [pattern, prompt] of Object.entries(savedPrompts)) {
+            const dbPrompt: Prompt = {
+                id: prompt.id || pattern,
+                name: prompt.name || pattern,
+                content: prompt.content,
+                pattern: prompt.pattern || pattern,
+                isDefault: prompt.isDefault || false,
+                selector: prompt.selector,
+            };
+            await dbSavePrompt(dbPrompt);
+        }
+
+        localStorage.setItem(MIGRATION_FLAG, 'true');
+    } catch (error) {
+        console.error('Failed to migrate prompts to IndexedDB:', error);
+    }
+}

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -1,4 +1,4 @@
-import { storage } from "./storage";
+import { dbGetAllPrompts, dbSavePrompt } from './db';
 
 export type Prompt = {
     id: string;
@@ -9,65 +9,22 @@ export type Prompt = {
     selector?: string; // CSS selector for the element to get content from
 };
 
-interface StorageData {
-    savedPrompts?: Record<string, {
-        content: string;
-        isDefault: boolean;
-        id: string;
-        name: string;
-        pattern: string;
-        selector?: string; // CSS selector for the element to get content from
-    }>;
-}
-
 // Save a prompt
 export async function savePrompt(prompt: Prompt) {
-    const result = await storage.sync.get('savedPrompts') as StorageData;
-    const savedPrompts = result.savedPrompts || {};
-
-    // If making this prompt default, remove default flag from others
-    if (prompt.isDefault) {
-        Object.keys(savedPrompts).forEach(key => {
-            if (savedPrompts[key].isDefault) {
-                savedPrompts[key] = {
-                    ...savedPrompts[key],
-                    isDefault: false
-                };
-            }
-        });
-    }
-
     // Clean pattern and save prompt
     const cleanPattern = prompt.pattern.replace(/^www\./, '');
-    savedPrompts[cleanPattern] = {
-        id: prompt.id,
-        name: prompt.name,
-        content: prompt.content,
+
+    await dbSavePrompt({
+        ...prompt,
         pattern: cleanPattern,
         isDefault: prompt.isDefault || false,
-        selector: prompt.selector || ''
-    };
-
-    await storage.sync.set({ savedPrompts });
+        selector: prompt.selector || '',
+    });
 }
 
-// Get all prompts including system default
+// Get all prompts
 export async function getPrompts(): Promise<Prompt[]> {
-    const result = await storage.sync.get('savedPrompts') as StorageData;
-    const savedPrompts = result.savedPrompts || {};
-
-    // Convert saved prompts to array format
-    const prompts = Object.entries(savedPrompts).map(([pattern, prompt]) => ({
-        id: pattern,
-        name: pattern,
-        content: prompt.content,
-        pattern,
-        isDefault: prompt.isDefault,
-        selector: prompt.selector
-    }));
-
-
-    return prompts;
+    return dbGetAllPrompts();
 }
 
 // Get the current default prompt (either user-set or system)

--- a/src/views/Home/ConversationItem.tsx
+++ b/src/views/Home/ConversationItem.tsx
@@ -1,0 +1,46 @@
+import { IoTrash } from 'react-icons/io5';
+import { ConversationSummary } from '@/views/Summary/types';
+
+interface ConversationItemProps {
+    conversation: ConversationSummary;
+    onClick: () => void;
+    onDelete: () => void;
+}
+
+function formatDate(timestamp: number): string {
+    const date = new Date(timestamp);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffMins < 1) return 'Just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return date.toLocaleDateString();
+}
+
+export const ConversationItem = ({ conversation, onClick, onDelete }: ConversationItemProps) => {
+    return (
+        <div className="conversation-item" onClick={onClick}>
+            <div className="conversation-item-content">
+                <div className="conversation-title">{conversation.title}</div>
+                <div className="conversation-meta">
+                    {formatDate(conversation.updatedAt)} &middot; {conversation.provider}/{conversation.model} &middot; {conversation.messageCount} messages
+                </div>
+            </div>
+            <button
+                className="conversation-delete"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete();
+                }}
+                title="Delete conversation"
+            >
+                <IoTrash size={14} />
+            </button>
+        </div>
+    );
+};

--- a/src/views/Home/ConversationList.tsx
+++ b/src/views/Home/ConversationList.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'wouter';
+import { useConversationsStore } from '@/stores/Conversations';
+import { ConversationItem } from './ConversationItem';
+
+export const ConversationList = () => {
+    const [, setLocation] = useLocation();
+    const {
+        conversations,
+        totalCount,
+        currentPage,
+        pageSize,
+        isLoading,
+        loadConversations,
+        loadConversation,
+        setPage,
+        setSearchQuery,
+        deleteConversation,
+    } = useConversationsStore();
+
+    const [localSearch, setLocalSearch] = useState('');
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        loadConversations();
+    }, []);
+
+    const handleSearchChange = (value: string) => {
+        setLocalSearch(value);
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => {
+            setSearchQuery(value);
+        }, 300);
+    };
+
+    const handleItemClick = async (id: string) => {
+        await loadConversation(id);
+        setLocation('/summary');
+    };
+
+    const totalPages = Math.ceil(totalCount / pageSize);
+
+    return (
+        <div className="conversation-list">
+            <label>Recent Conversations</label>
+            <input
+                type="text"
+                className="conversation-search"
+                placeholder="Search conversations..."
+                value={localSearch}
+                onChange={(e) => handleSearchChange(e.target.value)}
+            />
+
+            {isLoading && <div className="conversation-list-loading">Loading...</div>}
+
+            {!isLoading && conversations.length === 0 && (
+                <div className="conversation-list-empty">No conversations yet</div>
+            )}
+
+            {conversations.map((conv) => (
+                <ConversationItem
+                    key={conv.id}
+                    conversation={conv}
+                    onClick={() => handleItemClick(conv.id)}
+                    onDelete={() => deleteConversation(conv.id)}
+                />
+            ))}
+
+            {totalPages > 1 && (
+                <div className="pagination">
+                    <button
+                        className="btn"
+                        disabled={currentPage <= 1}
+                        onClick={() => setPage(currentPage - 1)}
+                    >
+                        &lt;
+                    </button>
+                    <span className="pagination-info">
+                        Page {currentPage} of {totalPages}
+                    </span>
+                    <button
+                        className="btn"
+                        disabled={currentPage >= totalPages}
+                        onClick={() => setPage(currentPage + 1)}
+                    >
+                        &gt;
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/views/Home/ConversationsView.tsx
+++ b/src/views/Home/ConversationsView.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useLocation } from 'wouter';
+import { useConversationsStore } from '@/stores/Conversations';
+import { ConversationItem } from './ConversationItem';
+import { BackButton } from '@/components/BackButton';
+
+export const ConversationsView = () => {
+    const [, setLocation] = useLocation();
+    const {
+        conversations,
+        totalCount,
+        currentPage,
+        pageSize,
+        isLoading,
+        loadConversations,
+        loadConversation,
+        setPage,
+        setSearchQuery,
+        deleteConversation,
+    } = useConversationsStore();
+
+    const [localSearch, setLocalSearch] = useState('');
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        loadConversations();
+    }, []);
+
+    const handleSearchChange = (value: string) => {
+        setLocalSearch(value);
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => {
+            setSearchQuery(value);
+        }, 300);
+    };
+
+    const handleItemClick = async (id: string) => {
+        await loadConversation(id);
+        setLocation('/summary');
+    };
+
+    const totalPages = Math.ceil(totalCount / pageSize);
+
+    return (
+        <div className="conversations-view">
+            <div className="conversations-header">
+                <Link href="/"><BackButton /></Link>
+                <h2>Recent Conversations</h2>
+            </div>
+            <input
+                type="text"
+                className="conversation-search"
+                placeholder="Search conversations..."
+                value={localSearch}
+                onChange={(e) => handleSearchChange(e.target.value)}
+            />
+
+            {isLoading && <div className="conversation-list-loading">Loading...</div>}
+
+            {!isLoading && conversations.length === 0 && (
+                <div className="conversation-list-empty">No conversations yet</div>
+            )}
+
+            <div className="conversation-list">
+                {conversations.map((conv) => (
+                    <ConversationItem
+                        key={conv.id}
+                        conversation={conv}
+                        onClick={() => handleItemClick(conv.id)}
+                        onDelete={() => deleteConversation(conv.id)}
+                    />
+                ))}
+            </div>
+
+            {totalPages > 1 && (
+                <div className="pagination">
+                    <button
+                        className="btn"
+                        disabled={currentPage <= 1}
+                        onClick={() => setPage(currentPage - 1)}
+                    >
+                        &lt;
+                    </button>
+                    <span className="pagination-info">
+                        Page {currentPage} of {totalPages}
+                    </span>
+                    <button
+                        className="btn"
+                        disabled={currentPage >= totalPages}
+                        onClick={() => setPage(currentPage + 1)}
+                    >
+                        &gt;
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -1,10 +1,11 @@
-import { useState, useRef, ChangeEvent } from "react";
+import { useState, useRef, useEffect, ChangeEvent } from "react";
 import { useLocation } from "wouter";
 import { toast } from 'react-toastify';
 import { GiBrainstorm } from "react-icons/gi";
 import { IoLogoYoutube } from "react-icons/io5";
 import { PromptSelector } from "./PromptSelector";
 import { useSummaryStore } from "@/stores/Summary";
+import { useConversationsStore } from "@/stores/Conversations";
 import { getVideoTitle } from "@/utils/url";
 import { fetchWebpage, getCurrentVideoId, fetchYouTubeTranscript } from "@/utils/content";
 import { ModelLabel } from "@/components/ModelLabel";
@@ -18,9 +19,14 @@ export const Home = () =>  {
     const { settings, isLoading, error } = useSettings();
     const [selectedPromptContent, setSelectedPromptContent] = useState<string>('');
     const [, setLocation] = useLocation();
-    const { setContent, setPrompt, enableChunking, setEnableChunking } = useSummaryStore();
+    const { setContent, setPrompt, setSourceUrl, enableChunking, setEnableChunking } = useSummaryStore();
+    const { clearActiveConversation } = useConversationsStore();
     const [selectedPath, setSelectedPath] = useState<string>('');
     const transcriptAreaRef = useRef<HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+        clearActiveConversation();
+    }, []);
 
     if (isLoading) {
         return <Loader />;
@@ -108,6 +114,7 @@ export const Home = () =>  {
 
 
             setContent(`${pageTitle}\n${userContent}`);
+            setSourceUrl(tab.url);
             setLocation('/summary');
         } catch (error) {
             toast.error('Error accessing page: ' + error);

--- a/src/views/PromptManager/PromptItem.tsx
+++ b/src/views/PromptManager/PromptItem.tsx
@@ -3,15 +3,15 @@ import { usePromptManagerStore } from "@/stores/SavedPrompts";
 
 type PromptItemProps = Prompt & { onEdit: (pattern: string) => void };
 
-export const PromptItem = ({ pattern, content, isDefault, selector, onEdit }: PromptItemProps) => {
+export const PromptItem = ({ id, pattern, content, isDefault, selector, onEdit }: PromptItemProps) => {
     const { deletePrompt, setDefaultPrompt } = usePromptManagerStore();
 
     const handleDelete = () => {
-        deletePrompt(pattern);
+        deletePrompt(id);
     };
 
     const handleSetDefault = () => {
-        setDefaultPrompt(pattern);
+        setDefaultPrompt(id);
     };
 
     return (

--- a/src/views/Summary/Summary.tsx
+++ b/src/views/Summary/Summary.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useState, KeyboardEvent } from 'react';
 import { Link } from 'wouter';
-import { IoSend, IoStopCircle } from "react-icons/io5";
+import { IoSend, IoStopCircle, IoGlobeOutline, IoLogoYoutube } from "react-icons/io5";
 import { toast } from 'react-toastify';
-import { handleStreamingResponse, updateTokenCount, estimateTokens, chunkAndSummarize } from '@/utils/chat';
+import { handleStreamingResponse, updateTokenCount, estimateTokens, chunkAndSummarize, generateConversationTitle } from '@/utils/chat';
+import { fetchWebpage, getCurrentVideoId, fetchYouTubeTranscript, cleanContent } from '@/utils/content';
+import { PathSelector } from '@/components/PathSelector';
 import { MessageList } from './MessageList';
 import { StreamingMessage } from './StreamingMessage';
 import { Message } from './types';
 import { useSummaryStore } from '@/stores/Summary';
+import { useConversationsStore } from '@/stores/Conversations';
 import { useAutoScroll } from '@/hooks/useAutoScroll';
 import { ModelLabel } from '@/components/ModelLabel';
 import { Loader } from '@/components/Loader';
@@ -15,7 +18,7 @@ import { useSettings } from '@/hooks/useSettings';
 import { BackButton } from '@/components/BackButton';
 
 export const Summary = () => {
-    const { content, prompt, enableChunking } = useSummaryStore();
+    const { content, prompt, enableChunking, sourceUrl } = useSummaryStore();
     const {
         settings,
         isLoading: settingsLoading,
@@ -29,9 +32,18 @@ export const Summary = () => {
     const [streamingMessage, setStreamingMessage] = useState<string>('');
     const chatInputRef = useRef<HTMLTextAreaElement>(null);
     const initializationRef = useRef(false);
+    const titleGeneratedRef = useRef(false);
     const { ref: messagesRef, scrollToBottom } = useAutoScroll([messages, streamingMessage]);
     const [chunkProgress, setChunkProgress] = useState<{ current: number; total: number; message: string } | null>(null);
     const abortControllerRef = useRef<AbortController | null>(null);
+
+    const {
+        activeConversationId,
+        activeMessages,
+        startNewConversation,
+        addMessage,
+        updateTitle,
+    } = useConversationsStore();
 
     const handleStop = () => {
         if (abortControllerRef.current) {
@@ -41,7 +53,9 @@ export const Summary = () => {
             setStreamingMessage('');
 
             // Add streaming message to messages
-            setMessages(prev => [...prev, { role: 'assistant', content: stoppedByUser }]);
+            const stoppedMessage: Message = { role: 'assistant', content: stoppedByUser };
+            setMessages(prev => [...prev, stoppedMessage]);
+            addMessage(stoppedMessage);
             scrollToBottom();
         }
     };
@@ -66,14 +80,17 @@ export const Summary = () => {
 
             // Add user message immediately and update token count
             let newMessages: Message[];
+            const userMessage: Message = { role: 'user', content: message };
+
             if (isInitial) {
                 // Show the initial message right away
-                newMessages = [{ role: 'user', content: message }];
+                newMessages = [userMessage];
             } else {
-                newMessages = [...messages, { role: 'user', content: message }];
+                newMessages = [...messages, userMessage];
             }
 
             setMessages(newMessages);
+            addMessage(userMessage);
             setTimeout(() => scrollToBottom(), 100); // Force scroll after adding user message
 
             // Initialize token count with current messages before streaming
@@ -104,8 +121,18 @@ export const Summary = () => {
             );
 
             // Add just the response to our history since we already added the message
-            setMessages(prev => [...prev, { role: 'assistant', content: response }]);
+            const assistantMessage: Message = { role: 'assistant', content: response };
+            setMessages(prev => [...prev, assistantMessage]);
+            addMessage(assistantMessage);
             setStreamingMessage('');
+
+            // Generate title after first assistant response
+            if (!titleGeneratedRef.current && isInitial) {
+                titleGeneratedRef.current = true;
+                generateConversationTitle(currentSettings, message, response)
+                    .then(title => updateTitle(title))
+                    .catch(() => {}); // keep fallback title
+            }
 
         } catch (error) {
             if (error instanceof Error && error.name === 'AbortError') {
@@ -126,9 +153,27 @@ export const Summary = () => {
                 return;
             }
 
-            const currentSettings = getProviderSettings(settings.provider);
             initializationRef.current = true;
+
+            // RESUME: if there's an active conversation with messages, restore them
+            if (activeConversationId && activeMessages.length > 0) {
+                setMessages(activeMessages);
+                titleGeneratedRef.current = true;
+                setIsLoading(false);
+                setTimeout(() => scrollToBottom(), 100);
+                return;
+            }
+
+            const currentSettings = getProviderSettings(settings.provider);
             abortControllerRef.current = new AbortController();
+
+            // Start a new conversation
+            startNewConversation(
+                settings.provider,
+                settings.model,
+                prompt,
+                sourceUrl || undefined
+            );
 
             try {
                 let contentToProcess = content; // Start with just the content
@@ -138,14 +183,14 @@ export const Summary = () => {
                 }
 
                 // Use currentSettings instead of settings
-                const estimatedTokens = estimateTokens(content);
+                const estimatedTokensCount = estimateTokens(content);
                 const systemPromptTokens = estimateTokens(prompt);
                 const messageFormatTokens = 8;
                 const safetyMargin = 50;
                 const totalOverhead = systemPromptTokens + messageFormatTokens + safetyMargin;
-                setTokenCount(estimatedTokens + totalOverhead);
+                setTokenCount(estimatedTokensCount + totalOverhead);
 
-                if (estimatedTokens + totalOverhead > currentSettings.num_ctx && enableChunking) {
+                if (estimatedTokensCount + totalOverhead > currentSettings.num_ctx && enableChunking) {
                     setChunkProgress({ current: 0, total: 0, message: 'Analyzing content size...' });
 
                     contentToProcess = await chunkAndSummarize(
@@ -199,6 +244,58 @@ export const Summary = () => {
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             handleSendMessage();
+        }
+    };
+
+    const insertContent = (text: string) => {
+        if (chatInputRef.current) {
+            chatInputRef.current.value = text;
+            chatInputRef.current.focus();
+        }
+    };
+
+    const handleFetchWebpage = async () => {
+        const content = await fetchWebpage();
+        if (content) {
+            insertContent(content);
+        }
+    };
+
+    const handleFetchTranscript = async () => {
+        const videoId = await getCurrentVideoId();
+        if (!videoId) {
+            toast.error("Could not determine video ID. Please ensure you're on a YouTube video page.");
+            return;
+        }
+        try {
+            const transcript = await fetchYouTubeTranscript();
+            if (transcript) {
+                insertContent(transcript);
+            }
+        } catch (error: unknown) {
+            toast.error(`Error fetching transcript: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    };
+
+    const handlePathSelected = async (selector: string) => {
+        try {
+            const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+            if (!tab.id) return;
+
+            const [{ result }] = await chrome.scripting.executeScript({
+                target: { tabId: tab.id },
+                func: (sel: string) => {
+                    const element = document.querySelector(sel);
+                    return element?.textContent?.trim() || '';
+                },
+                args: [selector]
+            });
+
+            if (result) {
+                insertContent(cleanContent(result));
+            }
+        } catch (error) {
+            console.error('Error getting element content:', error);
         }
     };
 
@@ -266,13 +363,23 @@ export const Summary = () => {
                             <Link href="/"><BackButton /></Link>
                             <div className="controls-send">
                                 <TokenDisplay tokenCount={Number(tokenCount)} max={Number(settings?.num_ctx)} />
-                                <button
-                                    id="send-message"
-                                    className="btn"
-                                    onClick={handleSendMessage}
-                                    disabled={isLoading} >
-                                    <IoSend />
-                                </button>
+                                <div className="chat-actions">
+                                    <PathSelector onPathSelected={handlePathSelected} compact />
+                                    <button className="btn icon-btn" onClick={handleFetchWebpage} title="Get Page Content" disabled={isLoading}>
+                                        <IoGlobeOutline size={18} />
+                                    </button>
+                                    <button className="btn icon-btn" onClick={handleFetchTranscript} title="Get Transcript" disabled={isLoading}>
+                                        <IoLogoYoutube size={18} />
+                                    </button>
+                                    <button
+                                        id="send-message"
+                                        className="btn icon-btn"
+                                        onClick={handleSendMessage}
+                                        title="Send Message"
+                                        disabled={isLoading} >
+                                        <IoSend size={18} />
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/views/Summary/types.ts
+++ b/src/views/Summary/types.ts
@@ -10,3 +10,25 @@ export interface AISettings {
     provider: string;
     api_key?: string;
 }
+
+export interface Conversation {
+    id: string;
+    title: string;
+    messages: Message[];
+    createdAt: number;
+    updatedAt: number;
+    provider: string;
+    model: string;
+    systemPrompt?: string;
+    sourceUrl?: string;
+}
+
+export interface ConversationSummary {
+    id: string;
+    title: string;
+    createdAt: number;
+    updatedAt: number;
+    provider: string;
+    model: string;
+    messageCount: number;
+}


### PR DESCRIPTION
## Summary
- **IndexedDB migration**: Prompt storage moved from `chrome.storage.sync` (100KB limit) to IndexedDB with automatic one-time migration preserving existing data
- **Conversation persistence**: All conversations auto-saved to IndexedDB with LLM-generated titles, resumable from a dedicated conversations view (`IoChatbubblesOutline` header button)
- **Chat input actions**: Added compact icon buttons (Select Content, Get Page Content, Get Transcript) in the chat controls for fetching content mid-conversation

## Test plan
- [ ] Load extension with existing prompts in chrome.storage.sync — verify they appear after migration
- [ ] Execute a prompt — verify conversation auto-saved, title generated after first response
- [ ] Click conversations header button — verify list shows with search and pagination
- [ ] Click a saved conversation — verify messages restore and chat scrolls to bottom
- [ ] Delete a conversation from the list — verify removed
- [ ] Use Select Content / Get Page Content / Get Transcript buttons in chat — verify content inserted into input
- [ ] `npm run build` compiles cleanly
- [ ] `npx vitest run` — existing tests pass